### PR TITLE
docs: warn about missing fragments support in <16

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ const Example = () => (
 `react-popper` makes use of a React pattern called **"render prop"**, if you are not
 familiar with it, please read more [on the official React documentation](https://reactjs.org/docs/render-props.html).
 
+> Using React <=15 or Preact? The components created with them don't support to return
+[fragments](https://reactjs.org/docs/fragments.html), this means that you will need to
+wrap `<Reference />` and `<Popper />` into a `<div />` to make `react-popper` work.
+
 ### API documentation
 
 The `Manager` component is a simple wrapper that needs to surround all the other `react-popper` components in order


### PR DESCRIPTION
React 15 and lower, and Preact, don't support components that return fragments. Added a warning in the documentation to help these users.