### PR TITLE
Export usePopper options type

### DIFF
--- a/typings/react-popper.d.ts
+++ b/typings/react-popper.d.ts
@@ -69,13 +69,15 @@ export class Popper<Modifiers> extends React.Component<
   {}
 > {}
 
+export type UsePopperOptions = Omit<Partial<PopperJS.Options>, 'modifiers'> & {
+  createPopper?: typeof PopperJS.createPopper;
+  modifiers?: ReadonlyArray<Modifier<Modifiers>>;
+}
+
 export function usePopper<Modifiers>(
   referenceElement?: Element | PopperJS.VirtualElement | null,
   popperElement?: HTMLElement | null,
-  options?: Omit<Partial<PopperJS.Options>, 'modifiers'> & {
-    createPopper?: typeof PopperJS.createPopper;
-    modifiers?: ReadonlyArray<Modifier<Modifiers>>;
-  }
+  options?: UsePopperOptions
 ): {
   styles: { [key: string]: React.CSSProperties };
   attributes: { [key: string]: { [key: string]: string } | undefined };


### PR DESCRIPTION
Exporting the options type is very useful as it is currently impossible to get it using `Parameters<typeof usePopper>[2]`  as extending an interface in Typescript will throw the error `An interface can only extend an identifier/qualified-name with optional type arguments` because of the `<TModifier extends Partial` inside `createPopper`'s type.