### PR TITLE
Fix Reference & Manager compatibility with React 18's StrictMode

### DIFF
--- a/src/Manager.js
+++ b/src/Manager.js
@@ -15,6 +15,7 @@ export function Manager({ children }: ManagerProps): React.Node {
 
   const hasUnmounted = React.useRef(false);
   React.useEffect(() => {
+    hasUnmounted.current = false;
     return () => {
       hasUnmounted.current = true;
     };

--- a/src/Reference.js
+++ b/src/Reference.js
@@ -22,10 +22,6 @@ export function Reference({ children, innerRef }: ReferenceProps): React.Node {
     [innerRef, setReferenceNode]
   );
 
-  // ran on unmount
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  React.useEffect(() => () => setRef(innerRef, null), []);
-
   React.useEffect(() => {
     warning(
       Boolean(setReferenceNode),


### PR DESCRIPTION
`Reference`, at least in how [BlueprintJS is using it](https://github.com/palantir/blueprint/blob/next/packages/core/src/components/popover/popover.tsx#L240), seems to be broken in React 18's StrictMode due to [effects running twice](https://github.com/reactwg/react-18/discussions/19). (This causes popovers to no longer close when clicking outside them and was very fun to track down.)

### Fixing Reference

https://github.com/floating-ui/react-popper/blob/master/src/Reference.js#L17-L27

In `Reference`, the `refHandler` passed to `children` as `ref` is only called by React once on initial mount. However, React 18 calls the `setRef(innerRef, null)` cleanup function after the `ref` has mounted, and `innerRef` ends up being cleared and left to `null`.

Since React [claims to always unmount ref callbacks](https://react.dev/reference/react-dom/components/common#ref-callback), I couldn't see a reason to manually set `innerRef` to `null` in a `useEffect` - so I'd think to just remove it.

### Fixing Manager

Additionally, `Manager` uses a "one-way" effect to keep track of mounting/unmounting - this is no longer compatible with React 18, so I added a line to reset the ref state when the effect is "remounted". Didn't bother tracking down a concrete bug with this, but at least this change shouldn't break anything.